### PR TITLE
Filter new query addresses for IRIDANext plug-in

### DIFF
--- a/modules/local/filter/main.nf
+++ b/modules/local/filter/main.nf
@@ -1,0 +1,49 @@
+process FILTER_NEW {
+    tag "Filter New Query Addresses"
+    label 'process_single'
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/csvtk:0.22.0--h9ee0642_1' :
+        'biocontainers/csvtk:0.22.0--h9ee0642_1' }"
+
+    input:
+    val input_query
+    path addresses
+    val in_format
+    val out_format
+
+    output:
+    path("new_addresses.csv"),  emit: csv
+    path("new_addresses.json"), emit: json
+
+    script:
+
+    def queryID = input_query[0].id
+    def outputFile = "new_addresses"
+
+    def delimiter = in_format == "tsv" ? "\t" : (in_format == "csv" ? "," : in_format)
+    def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
+    def out_extension = out_format == "tsv" ? 'tsv' : 'csv'
+
+    """
+    # Filter the query samples only; keep only the 'id' and 'address' columns
+    csvtk filter2 \\
+        ${addresses} \\
+        --filter '\$id == \"$queryID\"' \\
+        --delimiter "${delimiter}" \\
+        --out-delimiter "${out_delimiter}" \\
+        --out-file ${outputFile}.tmp
+
+    csvtk cut -f 1,2 ${outputFile}.tmp > ${outputFile}.${out_extension}
+    rm ${outputFile}.tmp
+
+    # Convert the CSV file to a JSON file array with 'id' as the key
+    csvtk csv2json ${outputFile}.${out_extension} -k id > ${outputFile}.json
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        csvtk: \$(echo \$( csvtk version | sed -e "s/csvtk v//g" ))
+    END_VERSIONS
+    """
+}
+

--- a/workflows/gas_nomenclature.nf
+++ b/workflows/gas_nomenclature.nf
@@ -26,6 +26,7 @@ include { LOCIDEX_MERGE as LOCIDEX_MERGE_REF    } from "../modules/local/locidex
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_QUERY  } from "../modules/local/locidex/merge/main"
 include { PROFILE_DISTS                         } from "../modules/local/profile_dists/main"
 include { GAS_CALL                              } from "../modules/local/gas/call/main"
+include { FILTER_NEW                            } from "../modules/local/filter/main"
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -117,30 +118,9 @@ workflow GAS_NOMENCLATURE {
 
     ch_versions = ch_versions.mix(called_data.versions)
 
+    // Filter the new queried samples and addresses into a CSV/JSON file for the IRIDANext plug in
 
-    // A channel of tuples of ({meta}, [read[0], read[1]], assembly)
-    //ch_tuple_read_assembly = input.join(ASSEMBLY_STUB.out.assembly)
-
-    //GENERATE_SAMPLE_JSON (
-    //    ch_tuple_read_assembly
-    //)
-    //ch_versions = ch_versions.mix(GENERATE_SAMPLE_JSON.out.versions)
-
-    //GENERATE_SUMMARY (
-    //    ch_tuple_read_assembly.collect{ [it] }
-    //)
-    //ch_versions = ch_versions.mix(GENERATE_SUMMARY.out.versions)
-
-    //SIMPLIFY_IRIDA_JSON (
-    //    GENERATE_SAMPLE_JSON.out.json
-    //)
-    //ch_versions = ch_versions.mix(SIMPLIFY_IRIDA_JSON.out.versions)
-    //ch_simplified_jsons = SIMPLIFY_IRIDA_JSON.out.simple_json.map { meta, data -> data }.collect() // Collect JSONs
-
-    //IRIDA_NEXT_OUTPUT (
-    //    samples_data=ch_simplified_jsons
-    //)
-    //ch_versions = ch_versions.mix(IRIDA_NEXT_OUTPUT.out.versions)
+    new_addresses = FILTER_NEW(profiles.query, called_data.distances, "tsv", "csv")
 
     CUSTOM_DUMPSOFTWAREVERSIONS (
         ch_versions.unique().collectFile(name: 'collated_versions.yml')


### PR DESCRIPTION
This PR creates a new module that filters the assigned addresses from `results.text` [from gas-call] to include only the query samples missing addresses for the 'nf-iridanext' plugin.

- Creates new module `FILTER_NEW`
- Adds the `nf-iridanext` plugin and configuration specs