### PR TITLE
Removed docker `quay.io` tags 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### `Changed`
+
+- Removed `quay.io` docker repository tags from modules [PR19](https://github.com/phac-nml/gasnomenclature/pull/19)
+
 ## [0.1.0] - 2024/06/28
 
 Initial release of the Genomic Address Nomenclature pipeline to be used to assign cluster addresses to samples based on an existing cluster designations.

--- a/modules/local/gas/call/main.nf
+++ b/modules/local/gas/call/main.nf
@@ -6,7 +6,7 @@ process GAS_CALL{
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.1.1--pyh7cba7a3_1' :
-        'quay.io/biocontainers/genomic_address_service:0.1.1--pyh7cba7a3_1' }"
+        'biocontainers/genomic_address_service:0.1.1--pyh7cba7a3_1' }"
 
 
     input:

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -6,7 +6,7 @@ process LOCIDEX_MERGE {
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     'https://depot.galaxyproject.org/singularity/locidex:0.1.1--pyhdfd78af_0' :
-    'quay.io/biocontainers/locidex:0.1.1--pyhdfd78af_0' }"
+    'biocontainers/locidex:0.1.1--pyhdfd78af_0' }"
 
     input:
     path input_values // [file(sample1), file(sample2), file(sample3), etc...]

--- a/modules/local/profile_dists/main.nf
+++ b/modules/local/profile_dists/main.nf
@@ -4,7 +4,7 @@ process PROFILE_DISTS{
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/profile_dists%3A1.0.0--pyh7cba7a3_0' :
-        'quay.io/biocontainers/profile_dists:1.0.0--pyh7cba7a3_0' }"
+        'biocontainers/profile_dists:1.0.0--pyh7cba7a3_0' }"
 
     input:
     path query


### PR DESCRIPTION
Removed docker `quay.io` tags from container closures in `gas` `profile_dists` and `locidex/merge`
