### PR TITLE
Upgrade profile_dists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2024/09/10
+
+### `Changed`
+
+- Upgraded `profile_dists` to version `1.0.2` in the container closure
+
 ## [0.2.0] - 2024/09/05
 
 ### `Changed`

--- a/modules/local/profile_dists/main.nf
+++ b/modules/local/profile_dists/main.nf
@@ -3,8 +3,9 @@ process PROFILE_DISTS{
     tag "Gathering Distances Between Reference and Query Profiles"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/profile_dists%3A1.0.0--pyh7cba7a3_0' :
-        'biocontainers/profile_dists:1.0.0--pyh7cba7a3_0' }"
+        'docker.io/mwells14/profile_dists:1.0.2' :
+        task.ext.override_configured_container_registry != false ? 'docker.io/mwells14/profile_dists:1.0.2' :
+        'mwells14/profile_dists:1.0.2' }" 
 
     input:
     path query

--- a/modules/local/profile_dists/main.nf
+++ b/modules/local/profile_dists/main.nf
@@ -5,7 +5,7 @@ process PROFILE_DISTS{
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'docker.io/mwells14/profile_dists:1.0.2' :
         task.ext.override_configured_container_registry != false ? 'docker.io/mwells14/profile_dists:1.0.2' :
-        'mwells14/profile_dists:1.0.2' }" 
+        'mwells14/profile_dists:1.0.2' }"
 
     input:
     path query

--- a/nextflow.config
+++ b/nextflow.config
@@ -222,7 +222,7 @@ manifest {
     description     = """Gas Nomenclature assignment pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.2.0'
+    version         = '0.2.1'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
This PR upgrades the container directive to use profiledists:1.0.2 for the `profile_dists` module.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
