### PR TITLE
Refactor FILTER_QUERY to Handle Query Sample IDs via File Input for csvtk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2024/09/..
+
+### `Changed`
+
+- Updated FILTER_QUERY to process query IDs from a file rather than passing them as a string, preventing errors caused by long argument strings [PR24](https://github.com/phac-nml/gasnomenclature/pull/24)
+
 ## [0.2.1] - 2024/09/10
 
 ### `Changed`
@@ -29,3 +35,5 @@ Initial release of the Genomic Address Nomenclature pipeline to be used to assig
 
 [0.1.0]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.1.0
 [0.2.0]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.2.0
+[0.2.1]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.2.1
+[0.2.2]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.2.2

--- a/modules/local/filter_query/main.nf
+++ b/modules/local/filter_query/main.nf
@@ -22,22 +22,15 @@ process FILTER_QUERY {
     def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
     def out_extension = out_format == "tsv" ? 'tsv' : 'csv'
 
-    // Write the query IDs to a temporary file
-    def queryFile = file("query_ids.txt")
-    queryFile.text = query_ids.join("\n")
-
     """
     # Filter the query samples only; keep only the 'id' and 'address' columns
     csvtk grep \\
         ${addresses} \\
         -f 1 \\
-        -P ${queryFile} \\
+        -P ${query_ids} \\
         --delimiter "${delimiter}" \\
         --out-delimiter "${out_delimiter}" | \\
     csvtk cut -f id,address > ${outputFile}.${out_extension}
-
-    # Remove the query_ids file after the command runs
-    rm -f ${queryFile}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -45,4 +38,3 @@ process FILTER_QUERY {
     END_VERSIONS
     """
 }
-

--- a/nextflow.config
+++ b/nextflow.config
@@ -222,7 +222,7 @@ manifest {
     description     = """Gas Nomenclature assignment pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.2.1'
+    version         = '0.2.2'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/workflows/gas_nomenclature.nf
+++ b/workflows/gas_nomenclature.nf
@@ -144,7 +144,7 @@ workflow GAS_NOMENCLATURE {
     ch_versions = ch_versions.mix(called_data.versions)
 
     // Filter the new queried samples and addresses into a CSV/JSON file for the IRIDANext plug in
-    query_ids = profiles.query.collect { it[0].id }
+    query_ids = profiles.query.collectFile { it[0].id + '\n' }
 
     new_addresses = FILTER_QUERY(query_ids, called_data.distances, "tsv", "csv")
     ch_versions = ch_versions.mix(new_addresses.versions)


### PR DESCRIPTION
The `FILTER_QUERY` module has been refactored to improve how query sample IDs are handled. Instead of passing sample IDs as individual strings to `csvtk filter2`, the IDs are now written to a single file (`.collectFile`) in the workflow and passed directly into `csvtk grep`.

This change prevents errors caused by overly long command-line strings and simplifies the process of handling large numbers of query samples efficiently.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

