### PR TITLE
Fix Input Handling for query_ids in FILTER_QUERY Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@ Initial release of the Genomic Address Nomenclature pipeline to be used to assig
 [0.2.0]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.2.0
 [0.2.1]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.2.1
 [0.2.2]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.2.2
+[0.2.3]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2024/09/20
+
+### `Changed`
+
+- Updated `FILTER_QUERY` process to treat `query_ids` as a file input (path instead of val) for proper file path handling across environments [PR27](https://github.com/phac-nml/gasnomenclature/pull/27)
+- Addressed [Issue26](https://github.com/phac-nml/gasnomenclature/issues/26)
+
 ## [0.2.2] - 2024/09/13
 
 ### `Changed`

--- a/modules/local/filter_query/main.nf
+++ b/modules/local/filter_query/main.nf
@@ -7,7 +7,7 @@ process FILTER_QUERY {
         'biocontainers/csvtk:0.22.0--h9ee0642_1' }"
 
     input:
-    val query_ids
+    path query_ids
     path addresses
     val in_format
     val out_format

--- a/nextflow.config
+++ b/nextflow.config
@@ -222,7 +222,7 @@ manifest {
     description     = """Gas Nomenclature assignment pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.2.2'
+    version         = '0.2.3'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
This PR addresses [Issue26](https://github.com/phac-nml/gasnomenclature/issues/26).

Problem:
In the `FILTER_QUERY` process, the input `query_ids` was originally defined as a `val`. However, `query_ids` is now stored as a file, and the process needs to reference the `path` to the file. This caused an issue where the file was being stored in a temporary directory, leading to file path resolution errors during execution, particularly on Azure.

Solution:
This PR changes the input for `query_ids` from:

`input: val query_ids` 
TO
`input: path query_ids`

- By switching to `path`, the process can correctly reference the file path and resolve the file during execution. 
- This change improves compatibility across environments, including local, cluster, and cloud setups (Azure).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
