### PR TITLE
Support for Additional Profiles and Clusters

### DIFF
--- a/modules/local/append_clusters/main.nf
+++ b/modules/local/append_clusters/main.nf
@@ -1,0 +1,21 @@
+process APPEND_CLUSTERS {
+    tag "Append additional clusters from database"
+    label 'process_single'
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/csvtk:0.22.0--h9ee0642_1' :
+        'biocontainers/csvtk:0.22.0--h9ee0642_1' }"
+
+    input:
+    path(initial_clusters)
+    path(additional_clusters)
+
+    output:
+    path("reference_clusters.tsv")
+
+    script:
+    """
+    csvtk concat -t ${initial_clusters} ${additional_clusters} > reference_clusters.tsv
+
+    """
+}

--- a/modules/local/append_profiles/main.nf
+++ b/modules/local/append_profiles/main.nf
@@ -1,0 +1,20 @@
+process APPEND_PROFILES {
+    tag "Append additional reference profiles"
+    label 'process_single'
+
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/csvtk:0.22.0--h9ee0642_1' :
+        'biocontainers/csvtk:0.22.0--h9ee0642_1' }"
+
+    input:
+    path(reference_profiles)
+    path(additional_profiles)
+
+    output:
+    path("*.tsv")
+
+    script:
+    """
+    csvtk concat -t ${reference_profiles} ${additional_profiles} > profiles_ref.tsv
+    """
+}

--- a/modules/local/cluster_file/main.nf
+++ b/modules/local/cluster_file/main.nf
@@ -6,7 +6,7 @@ process CLUSTER_FILE {
     val meta
 
     output:
-    path("reference_clusters.txt"), emit: text
+    path("clusters.tsv")
 
     exec:
     def outputLines = []
@@ -37,7 +37,7 @@ process CLUSTER_FILE {
     }
 
     // Write the text file, iterating over each sample
-    task.workDir.resolve("reference_clusters.txt").withWriter { writer ->
+    task.workDir.resolve("clusters.tsv").withWriter { writer ->
         outputLines.each { line ->
             writer.writeLine(line)
         }

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,6 +59,10 @@ params {
     gm_method = "average"
     gm_delimiter = "."
 
+    // Additional Profile and Cluster Databases for Reference Samples 
+    db_profiles = null
+    db_clusters = null 
+
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,9 +59,9 @@ params {
     gm_method = "average"
     gm_delimiter = "."
 
-    // Additional Profile and Cluster Databases for Reference Samples 
+    // Additional Profile and Cluster Databases for Reference Samples
     db_profiles = null
-    db_clusters = null 
+    db_clusters = null
 
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -122,6 +122,30 @@
                 }
             }
         },
+
+        "databases": {
+            "title": "Databases",
+            "type": "object",
+            "description": "The optional databases of profiles and cluster addresses that can be used.",
+            "fa_icon": "fas fa-terminal",
+            "default": "",
+            "properties": {
+                "db_profiles": {
+                    "type": "string",
+                    "pattern": "^\\S+\\.tsv$",
+                    "format": "file-path",
+                    "hidden": true,
+                    "description": "Path to optional tab-separated file containing additional sample profiles"
+                },
+                "db_clusters": {
+                    "type": "string",
+                    "pattern": "^\\S+\\.tsv$",
+                    "format": "file-path",
+                    "hidden": true,
+                    "description": "Path to optional text file containing additional sample cluster addresses"
+                }
+            }
+        },
         "institutional_config_options": {
             "title": "Institutional config options",
             "type": "object",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -311,6 +311,9 @@
             "$ref": "#/definitions/input_output_options"
         },
         {
+            "$ref": "#/definitions/databases"
+        },
+        {
             "$ref": "#/definitions/institutional_config_options"
         },
         {

--- a/workflows/gas_nomenclature.nf
+++ b/workflows/gas_nomenclature.nf
@@ -25,10 +25,10 @@ include { paramsSummaryLog; paramsSummaryMap; fromSamplesheet  } from 'plugin/nf
 include { INPUT_ASSURE                          } from "../modules/local/input_assure/main"
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_REF    } from "../modules/local/locidex/merge/main"
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_QUERY  } from "../modules/local/locidex/merge/main"
-include { APPEND_PROFILES                       } from "../modules/local/append_profiles/main"      
+include { APPEND_PROFILES                       } from "../modules/local/append_profiles/main"
 include { PROFILE_DISTS                         } from "../modules/local/profile_dists/main"
 include { CLUSTER_FILE                          } from "../modules/local/cluster_file/main"
-include { APPEND_CLUSTERS                       } from "../modules/local/append_clusters/main"      
+include { APPEND_CLUSTERS                       } from "../modules/local/append_clusters/main"
 include { GAS_CALL                              } from "../modules/local/gas/call/main"
 include { FILTER_QUERY                          } from "../modules/local/filter_query/main"
 
@@ -103,7 +103,7 @@ workflow GAS_NOMENCLATURE {
         }
 
         merged_references = APPEND_PROFILES(references.combined_profiles, additional_profiles)
-    } else { 
+    } else {
         merged_references = references.combined_profiles
     }
 
@@ -134,7 +134,7 @@ workflow GAS_NOMENCLATURE {
         meta }
 
     initial_clusters = CLUSTER_FILE(clusters)
-        
+
     // Run APPEND_CLUSTERS if db_clusters parameter provided
     if(params.db_clusters) {
         additional_clusters = prepareFilePath(params.db_clusters, "Appending additional cluster addresses from ${params.db_clusters}")
@@ -145,8 +145,8 @@ workflow GAS_NOMENCLATURE {
         expected_clusters = APPEND_CLUSTERS(initial_clusters, additional_clusters)
     } else {
         expected_clusters = initial_clusters
-    }    
-        
+    }
+
     // GAS CALL processes
 
     if(params.gm_thresholds == null || params.gm_thresholds == ""){

--- a/workflows/gas_nomenclature.nf
+++ b/workflows/gas_nomenclature.nf
@@ -25,8 +25,10 @@ include { paramsSummaryLog; paramsSummaryMap; fromSamplesheet  } from 'plugin/nf
 include { INPUT_ASSURE                          } from "../modules/local/input_assure/main"
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_REF    } from "../modules/local/locidex/merge/main"
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_QUERY  } from "../modules/local/locidex/merge/main"
+include { APPEND_PROFILES                       } from "../modules/local/append_profiles/main"      
 include { PROFILE_DISTS                         } from "../modules/local/profile_dists/main"
 include { CLUSTER_FILE                          } from "../modules/local/cluster_file/main"
+include { APPEND_CLUSTERS                       } from "../modules/local/append_clusters/main"      
 include { GAS_CALL                              } from "../modules/local/gas/call/main"
 include { FILTER_QUERY                          } from "../modules/local/filter_query/main"
 
@@ -87,11 +89,25 @@ workflow GAS_NOMENCLATURE {
     ref_tag = Channel.value("ref")
     query_tag = Channel.value("value")
 
-    merged_references = LOCIDEX_MERGE_REF(reference_values, ref_tag)
-    ch_versions = ch_versions.mix(merged_references.versions)
+    references = LOCIDEX_MERGE_REF(reference_values, ref_tag)
+    ch_versions = ch_versions.mix(references.versions)
 
-    merged_queries = LOCIDEX_MERGE_QUERY(query_values, query_tag)
-    ch_versions = ch_versions.mix(merged_queries.versions)
+    queries = LOCIDEX_MERGE_QUERY(query_values, query_tag)
+    ch_versions = ch_versions.mix(queries.versions)
+
+    // Run APPEND_PROFILES if db_profiles parameter provided; update merged_profiles and merged_queries
+    if(params.db_profiles) {
+        additional_profiles = prepareFilePath(params.db_profiles, "Appending additional samples from ${params.db_profiles} to reference profiles")
+        if(additional_profiles == null) {
+        exit 1, "${params.db_profiles}: Does not exist but was passed to the pipeline. Exiting now."
+        }
+
+        merged_references = APPEND_PROFILES(references.combined_profiles, additional_profiles)
+    } else { 
+        merged_references = references.combined_profiles
+    }
+
+    merged_queries = queries.combined_profiles
 
     // PROFILE DISTS processes
 
@@ -105,8 +121,8 @@ workflow GAS_NOMENCLATURE {
         exit 1, "${params.pd_columns}: Does not exist but was passed to the pipeline. Exiting now."
     }
 
-    distances = PROFILE_DISTS(merged_queries.combined_profiles,
-                            merged_references.combined_profiles,
+    distances = PROFILE_DISTS(merged_queries,
+                            merged_references,
                             mapping_file,
                             columns_file)
     ch_versions = ch_versions.mix(distances.versions)
@@ -117,8 +133,20 @@ workflow GAS_NOMENCLATURE {
     }.collect { meta, file ->
         meta }
 
-    expected_clusters = CLUSTER_FILE(clusters)
+    initial_clusters = CLUSTER_FILE(clusters)
+        
+    // Run APPEND_CLUSTERS if db_clusters parameter provided
+    if(params.db_clusters) {
+        additional_clusters = prepareFilePath(params.db_clusters, "Appending additional cluster addresses from ${params.db_clusters}")
+        if(additional_clusters == null) {
+        exit 1, "${params.db_clusters}: Does not exist but was passed to the pipeline. Exiting now."
+        }
 
+        expected_clusters = APPEND_CLUSTERS(initial_clusters, additional_clusters)
+    } else {
+        expected_clusters = initial_clusters
+    }    
+        
     // GAS CALL processes
 
     if(params.gm_thresholds == null || params.gm_thresholds == ""){
@@ -140,7 +168,7 @@ workflow GAS_NOMENCLATURE {
         exit 1, "'--pd_distm ${params.pd_distm}' is an invalid value. Please set to either 'hamming' or 'scaled'."
     }
 
-    called_data = GAS_CALL(expected_clusters.text, distances.results)
+    called_data = GAS_CALL(expected_clusters, distances.results)
     ch_versions = ch_versions.mix(called_data.versions)
 
     // Filter the new queried samples and addresses into a CSV/JSON file for the IRIDANext plug in


### PR DESCRIPTION
**This pull request is a work in progress and is not yet complete.**

This update aims to enhance the pipeline by integrating additional reference profiles and clusters from user-provided database parameters:

- `--db_profiles` will be incorporated through the `APPEND_PROFILES` process (which follows `LOCIDEX_MERGE_REF`).
- `--db_clusters` will be integrated via the `APPEND_CLUSTERS` process (which follows `CLUSTER_FILE`).

Both parameters are required for their respective processes, and users must provide both; it is not possible to supply only one.

Please note that tests are currently failing, and further tests will need to be implemented. 
No documentation has been updated yet. 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/phac-nml/gasnomenclature/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
