### PR TITLE
Update: Add `sample_name` for IRIDA-Next integration 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,3 +30,8 @@ indent_style = unset
 # ignore python
 [*.{py}]
 indent_style = unset
+
+# ignore nf-test json file
+[tests/data/irida/sample_name_add_iridanext.output.json]
+end_of_line = unset
+trim_trailing_whitespace = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -33,5 +33,5 @@ indent_style = unset
 
 # ignore nf-test json file
 [tests/data/irida/sample_name_add_iridanext.output.json]
-end_of_line = unset
+insert_final_newline = unset
 trim_trailing_whitespace = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,6 @@ indent_style = unset
 indent_style = unset
 
 # ignore nf-test json file
-[tests/data/irida/*.{json}]
+[tests/data/irida/*.json]
 insert_final_newline = unset
 trim_trailing_whitespace = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,6 @@ indent_style = unset
 indent_style = unset
 
 # ignore nf-test json file
-[tests/data/irida/sample_name_add_iridanext.output.json]
+[tests/data/irida/*.{json}]
 insert_final_newline = unset
 trim_trailing_whitespace = unset

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+        run: nf-core -l lint_log.txt lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Run nf-core pipelines lint --release
         if: ${{ github.base_ref == 'master' }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,6 @@
 name: nf-core linting
 # This workflow is triggered on pushes and PRs to the repository.
-# It runs the `nf-core lint` and markdown lint tests to ensure
+# It runs the `nf-core pipelines lint` and markdown lint tests to ensure
 # that the code meets the nf-core guidelines.
 on:
   push:
@@ -41,17 +41,32 @@ jobs:
           python-version: "3.12"
           architecture: "x64"
 
+      - name: read .nf-core.yml
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: read_yml
+        with:
+          config: ${{ github.workspace }}/.nf-core.yml
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nf-core
+          pip install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
 
-      - name: Run nf-core lint
+      - name: Run nf-core pipelines lint
+        if: ${{ github.base_ref != 'master' }}
         env:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
         run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+
+      - name: Run nf-core pipelines lint --release
+        if: ${{ github.base_ref == 'master' }}
+        env:
+          GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
+        run: nf-core -l lint_log.txt pipelines lint --release --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Save PR number
         if: ${{ always() }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -51,7 +51,7 @@ jobs:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+        run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Save PR number
         if: ${{ always() }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+        run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Run nf-core pipelines lint --release
         if: ${{ github.base_ref == 'master' }}

--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download lint results
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: linting.yml
           workflow_conclusion: completed

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,6 +1,6 @@
 repository_type: pipeline
 
-nf_core_version: "2.14.1"
+nf_core_version: "3.0.1"
 lint:
   files_exist:
     - assets/nf-core-gasnomenclature_logo_light.png

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -27,6 +27,9 @@ lint:
     - custom_config
     - manifest.name
     - manifest.homePage
+    - params.max_cpus
+    - params.max_memory
+    - params.max_time
   readme:
     - nextflow_badge
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ testing/
 testing*
 *.pyc
 bin/
+tests/data/irida/sample_name_add_iridanext.output.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Development
+
+### Changed
+
+- Added the ability to include a `sample_name` column in the input samplesheet.csv. Allows for compatibility with IRIDA-Next input configuration.
+  - `sample_name` special characters will be replaced with `"_"`
+  - If no `sample_name` is supplied in the column `sample` will be used
+  - To avoid repeat values for `sample_name` all `sample_name` values will be suffixed with the unique `sample` value from the input file
+
 ## [0.2.3] - 2024/09/25
 
 ### `Changed`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ The structure of this file is defined in [assets/schema_input.json](assets/schem
 
 Details on the columns can be found in the [Full samplesheet](docs/usage.md#full-samplesheet) documentation.
 
+## IRIDA-Next Optional Input Configuration
+
+`gasnomenclature` accepts the [IRIDA-Next](https://github.com/phac-nml/irida-next) format for samplesheets which can contain an additional column: `sample_name`
+
+`sample_name`: An **optional** column, that overrides `sample` for outputs (filenames and sample names) and reference assembly identification.
+
+`sample_name`, allows more flexibility in naming output files or sample identification. Unlike `sample`, `sample_name` is not required to contain unique values. `Nextflow` requires unique sample names, and therefore in the instance of repeat `sample_names`, `sample` will be suffixed to any `sample_name`. Non-alphanumeric characters (excluding `_`,`-`,`.`) will be replaced with `"_"`.
+
+An [example samplesheet](tests/data/samplesheets/samplesheet-sample_name.csv) has been provided with the pipeline.
+
 # Parameters
 
 The main parameters are `--input` as defined above and `--output` for specifying the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run.

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -10,9 +10,14 @@
             "sample": {
                 "type": "string",
                 "pattern": "^\\S+$",
-                "meta": ["id"],
+                "meta": ["irida_id"],
                 "unique": true,
                 "errorMessage": "Sample name must be provided and cannot contain spaces"
+            },
+            "sample_name": {
+                "type": "string",
+                "meta": ["id"],
+                "errorMessage": "Sample name is optional, if provided will replace sample for filenames and outputs"
             },
             "mlst_alleles": {
                 "type": "string",

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/phac-nml/gasnomenclature/main/assets/schema_input.json",
     "title": "phac-nml/gasnomenclature pipeline - params.input schema",
     "description": "Schema for the file provided with params.input",

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -4,13 +4,13 @@ iridanext {
         path = "${params.outdir}/iridanext.output.json.gz"
         overwrite = true
         files {
-            samples = ["${params.outdir}/input/*_error_report.csv"]
+            samples = ["**/input/*_error_report.csv"]
         }
         metadata {
             idkey = "id_irida"
             samples {
                 csv {
-                    path = "${params.outdir}/filter/new_addresses.csv"
+                    path = "**/filter/new_addresses.csv"
                     idcol = "id"
                 }
             }

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -4,12 +4,13 @@ iridanext {
         path = "${params.outdir}/iridanext.output.json.gz"
         overwrite = true
         files {
-            samples = ["**/input/*_error_report.csv"]
+            samples = ["${params.outdir}/input/*_error_report.csv"]
         }
         metadata {
+            idkey = "id_irida"
             samples {
                 csv {
-                    path = "**/filter/new_addresses.csv"
+                    path = "${params.outdir}/filter/new_addresses.csv"
                     idcol = "id"
                 }
             }

--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -4,14 +4,18 @@ iridanext {
         path = "${params.outdir}/iridanext.output.json.gz"
         overwrite = true
         files {
+            idkey = "irida_id"
             samples = ["**/input/*_error_report.csv"]
         }
         metadata {
-            idkey = "id_irida"
             samples {
+                keep = [
+                    "address"
+                ]
                 csv {
-                    path = "**/filter/new_addresses.csv"
-                    idcol = "id"
+                    path = "**/filter/new_addresses.tsv"
+                    sep = "\t"
+                    idcol = 'irida_id'
                 }
             }
         }

--- a/docs/output.md
+++ b/docs/output.md
@@ -93,7 +93,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 <summary>Output files</summary>
 
 - `filter/`
-  - `new_addresses.csv`
+  - `new_addresses.tsv`
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ You will need to create a samplesheet with information about the samples you wou
 --input '[path to samplesheet file]'
 ```
 
-### Full samplesheet
+### Full Standard Samplesheet
 
 The input samplesheet must contain three columns: `sample`, `mlst_alleles`, `address`. The sample names within a samplesheet should be unique. All other columns will be ignored.
 
@@ -32,6 +32,28 @@ sampleF,sampleF.mlst.json,
 | `address`      | Hierarchal clustering address. If left empty for a sample, the pipeline will assign a cluster address.                                                                                                                                                                                                                           |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
+
+### IRIDA-Next Optional Samplesheet Configuration
+
+`gasnomenclature` accepts the [IRIDA-Next](https://github.com/phac-nml/irida-next) format for samplesheets which contain the following columns: `sample`, `sample_name`, `mlst_alleles`, `address`. The sample IDs within a samplesheet should be unique.
+
+A final samplesheet file consisting of mlst_alleles and addresses may look something like the one below:
+
+```csv title="samplesheet.csv"
+sample,sample_name,mlst_alleles,address
+sampleA,S1,sampleA.mlst.json.gz,1.1.1
+sampleQ,S2,sampleQ.mlst.json.gz,2.2.2
+sampleF,,sampleF.mlst.json,
+```
+
+| Column         | Description                                                                                                                                                                                                                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sample`       | Custom sample name. Samples should be unique within a samplesheet.                                                                                                                                                                                                                          |
+| `sample_name`  | Sample name used in outputs (filenames and sample names)                                                                                                                                                                                                                                    |
+| `mlst_alleles` | Full path to an MLST JSON file describing the loci/alleles for the sample against some MLST scheme. A way to generate this file is via [locidex]. File can optionally be gzipped and must have the extension ".mlst.json", ".mlst.subtyping.json" (or with an additional ".gz" if gzipped). |
+| `address`      | Hierarchal clustering address. If left empty for a sample, the pipeline will assign a cluster address.                                                                                                                                                                                      |
+
+An [example samplesheet](tests/data/samplesheets/samplesheet-sample_name.csv) has been provided with the pipeline.
 
 ## Running the pipeline
 
@@ -185,3 +207,5 @@ We recommend adding the following line to your environment to limit this (typica
 ```bash
 NXF_OPTS='-Xms1g -Xmx4g'
 ```
+
+[locidex]: https://github.com/phac-nml/locidex

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/phac-nml/gasnomenclature/main/nextflow_schema.json",
     "title": "phac-nml/gasnomenclature pipeline parameters",
     "description": "Gas Nomenclature assignment pipeline",
@@ -84,8 +84,7 @@
                 },
                 "pd_count_missing": {
                     "type": "boolean",
-                    "description": "Count missing alleles as different",
-                    "default": false
+                    "description": "Count missing alleles as different"
                 }
             }
         },

--- a/tests/data/irida/sample_name_add_iridanext.output.json
+++ b/tests/data/irida/sample_name_add_iridanext.output.json
@@ -1,0 +1,31 @@
+{
+    "files": {
+        "global": [
+            
+        ],
+        "samples": {
+            "sample_1": [
+                {
+                    "path": "input/sample_1_error_report.csv"
+                }
+            ],
+            "sample_2_sample2": [
+                {
+                    "path": "input/sample_2_sample2_error_report.csv"
+                }
+            ],
+            "sample_2": [
+                {
+                    "path": "input/sample_2_error_report.csv"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "samples": {
+            "sample_1": {
+                "address": "1.1.3"
+            }
+        }
+    }
+}

--- a/tests/data/irida/sample_name_add_iridanext.output.json
+++ b/tests/data/irida/sample_name_add_iridanext.output.json
@@ -1,30 +1,38 @@
 {
     "files": {
         "global": [
-            
+
         ],
         "samples": {
-            "sample_1": [
+            "sampleQ": [
                 {
                     "path": "input/sample_1_error_report.csv"
                 }
             ],
-            "sample_2_sample2": [
+            "sample1": [
+                {
+                    "path": "input/sample_2_error_report.csv"
+                }
+            ],
+            "sample2": [
                 {
                     "path": "input/sample_2_sample2_error_report.csv"
                 }
             ],
-            "sample_2": [
+            "sampleR": [
                 {
-                    "path": "input/sample_2_error_report.csv"
+                    "path": "input/sample4_error_report.csv"
                 }
             ]
         }
     },
     "metadata": {
         "samples": {
-            "sample_1": {
-                "address": "1.1.3"
+            "sampleQ": {
+                "address": "2.2.3"
+            },
+            "sampleR": {
+                "address": "2.2.3"
             }
         }
     }

--- a/tests/data/samplesheets/samplesheet-sample_name.csv
+++ b/tests/data/samplesheets/samplesheet-sample_name.csv
@@ -3,3 +3,4 @@ sampleQ,sample 1,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/
 sample1,sample#2,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample1.mlst.json,1.1.1
 sample2,sample#2,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample2.mlst.json,1.1.1
 sample3,,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample3.mlst.json,1.1.2
+sampleR,sample4,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sampleF.mlst.json,

--- a/tests/data/samplesheets/samplesheet-sample_name.csv
+++ b/tests/data/samplesheets/samplesheet-sample_name.csv
@@ -1,0 +1,5 @@
+sample,sample_name,mlst_alleles,address
+sampleQ,sample 1,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sampleQ.mlst.json,
+sample1,sample#2,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample1.mlst.json,1.1.1
+sample2,sample#2,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample2.mlst.json,1.1.1
+sample3,,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample3.mlst.json,1.1.2

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -354,4 +354,43 @@ nextflow_pipeline {
             assert (workflow.stdout =~ /sample2_empty.mlst.json is missing the 'profile' section or is completely empty!/).find()
         }
     }
+
+    test("Testing when sample_name column is included on input"){
+        // For integration in IRIDA-Next there needs to be an option to have the input file include a sample_name column
+
+        tag "add-sample-name"
+
+        when{
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-sample_name.csv"
+                outdir = "results"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check outputs
+            def lines = []
+
+            // Ensure that the error_reports are generated for query and reference samples based on sample_name swap with sample
+            lines = path("$launchDir/results/input/sample_1_error_report.csv").readLines()
+            assert lines.contains("sample_1,[\'sampleQ\'],Query sample_1 ID and JSON key in sampleQ.mlst.json DO NOT MATCH. The 'sampleQ' key in sampleQ.mlst.json has been forcefully changed to 'sample_1': User should manually check input files to ensure correctness.")
+
+            lines = path("$launchDir/results/input/sample_2_error_report.csv").readLines()
+            assert lines.contains("sample_2,[\'sample1\'],Reference sample_2 ID and JSON key in sample1.mlst.json DO NOT MATCH. The 'sample1' key in sample1.mlst.json has been forcefully changed to 'sample_2': User should manually check input files to ensure correctness.")
+
+            lines = path("$launchDir/results/input/sample_2_sample2_error_report.csv").readLines()
+            assert lines.contains("sample_2_sample2,[\'sample2\'],Reference sample_2_sample2 ID and JSON key in sample2.mlst.json DO NOT MATCH. The 'sample2' key in sample2.mlst.json has been forcefully changed to 'sample_2_sample2': User should manually check input files to ensure correctness.")
+
+            // Check filter_query csv file
+            lines = path("$launchDir/results/filter/new_addresses.csv").readLines()
+            assert lines.contains("sample_1,1.1.3")
+
+            // Check IRIDA Next JSON output
+            assert path("$launchDir/results/iridanext.output.json").json == path("$baseDir/tests/data/irida/sample_name_add_iridanext.output.json").json
+
+        }
+    }
 }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -221,9 +221,9 @@ nextflow_pipeline {
             assert lines.contains("sampleR,[\'sampleF\'],Query sampleR ID and JSON key in sampleF.mlst.json DO NOT MATCH. The 'sampleF' key in sampleF.mlst.json has been forcefully changed to 'sampleR': User should manually check input files to ensure correctness.")
 
             // Check filter_query csv file
-            lines = path("$launchDir/results/filter/new_addresses.csv").readLines()
-            assert lines.contains("sampleQ,2.2.3")
-            assert lines.contains("sampleR,2.2.3")
+            lines = path("$launchDir/results/filter/new_addresses.tsv").readLines()
+            assert lines.contains("sampleQ\tsampleQ\t2.2.3")
+            assert lines.contains("sampleR\tsampleR\t2.2.3")
 
             // Check IRIDA Next JSON output
             assert path("$launchDir/results/iridanext.output.json").json == path("$baseDir/tests/data/irida/mismatched_iridanext.output.json").json
@@ -271,8 +271,8 @@ nextflow_pipeline {
             assert lines.contains('sample3,"[\'extra_key\', \'sample3\']","MLST JSON file (sample3_multiplekeys.mlst.json) contains multiple keys: [\'extra_key\', \'sample3\']. The MLST JSON file has been modified to retain only the \'sample3\' entry"')
 
             // Check filtered query csv results
-            lines = path("$launchDir/results/filter/new_addresses.csv").readLines()
-            assert lines.contains("sampleQ,1.1.3")
+            lines = path("$launchDir/results/filter/new_addresses.tsv").readLines()
+            assert lines.contains("sampleQ\tsampleQ\t1.1.3")
 
             // Check IRIDA Next JSON output
             assert path("$launchDir/results/iridanext.output.json").json == path("$baseDir/tests/data/irida/multiplekeys_iridanext.output.json").json
@@ -320,8 +320,8 @@ nextflow_pipeline {
             assert lines.contains('sample3,"[\'extra_key\', \'sample4\']",No key in the MLST JSON file (sample3_multiplekeys_nomatch.mlst.json) matches the specified sample ID \'sample3\'. The first key \'extra_key\' has been forcefully changed to \'sample3\' and all other keys have been removed.')
 
             // Check filtered query csv results
-            lines = path("$launchDir/results/filter/new_addresses.csv").readLines()
-            assert lines.contains("sampleQ,1.1.3")
+            lines = path("$launchDir/results/filter/new_addresses.tsv").readLines()
+            assert lines.contains("sampleQ\tsampleQ\t1.1.3")
 
             // Check IRIDA Next JSON output
             assert path("$launchDir/results/iridanext.output.json").json == path("$baseDir/tests/data/irida/multiplekeys_iridanext.output.json").json
@@ -385,8 +385,9 @@ nextflow_pipeline {
             assert lines.contains("sample_2_sample2,[\'sample2\'],Reference sample_2_sample2 ID and JSON key in sample2.mlst.json DO NOT MATCH. The 'sample2' key in sample2.mlst.json has been forcefully changed to 'sample_2_sample2': User should manually check input files to ensure correctness.")
 
             // Check filter_query csv file
-            lines = path("$launchDir/results/filter/new_addresses.csv").readLines()
-            assert lines.contains("sample_1,1.1.3")
+            lines = path("$launchDir/results/filter/new_addresses.tsv").readLines()
+            assert lines.contains("sampleQ\tsample_1\t2.2.3")
+            assert lines.contains("sampleR\tsample4\t2.2.3")
 
             // Check IRIDA Next JSON output
             assert path("$launchDir/results/iridanext.output.json").json == path("$baseDir/tests/data/irida/sample_name_add_iridanext.output.json").json

--- a/workflows/gas_nomenclature.nf
+++ b/workflows/gas_nomenclature.nf
@@ -68,18 +68,41 @@ workflow GAS_NOMENCLATURE {
 
     ch_versions = Channel.empty()
 
+    // Track processed IDs
+    def processedIDs = [] as Set
+
     // Create a new channel of metadata from a sample sheet
     // NB: `input` corresponds to `params.input` and associated sample sheet schema
     input = Channel.fromSamplesheet("input")
+    // and remove non-alphanumeric characters in sample_names (meta.id), whilst also correcting for duplicate sample_names (meta.id)
+    .map { meta, mlst_file ->
+            if (!meta.id) {
+                meta.id = meta.irida_id
+            } else {
+                // Non-alphanumeric characters (excluding _,-,.) will be replaced with "_"
+                meta.id = meta.id.replaceAll(/[^A-Za-z0-9_.\-]/, '_')
+            }
+            // Ensure ID is unique by appending meta.irida_id if needed
+            while (processedIDs.contains(meta.id)) {
+                meta.id = "${meta.id}_${meta.irida_id}"
+            }
+            // Add the ID to the set of processed IDs
+            processedIDs << meta.id
+
+            tuple(meta, mlst_file)}
+
+
 
     // Ensure meta.id and mlst_file keys match; generate error report for samples where id ≠ key
     input_assure = INPUT_ASSURE(input)
     ch_versions = ch_versions.mix(input_assure.versions)
 
-    // Prepare reference and query TSV files for LOCIDEX_MERGE
+    // Collect samples without address
     profiles = input_assure.result.branch {
         query: !it[0].address
     }
+
+    // Prepare reference and query TSV files for LOCIDEX_MERGE
     reference_values = input_assure.result.collect{ meta, mlst -> mlst}
     query_values = profiles.query.collect{ meta, mlst -> mlst }
 


### PR DESCRIPTION
Modified the template for input `samplesheet.csv` file to include the `sample_name` column in addition to `sample` in-line with changes to [IRIDA-Next update] as seen with the [speciesabundance pipeline] , [staramrnf] and [arboratornf]. What this means is that the output files and the `sample` name will be changed to `sample_name` if a `sample_name` is called. If `arborator` is being locally run then the `sample_name` can be left blank.

Made a few changes:
    - `sample_name` special characters will be replaced with `"_"`
    - If no `sample_name` is supplied in the column `sample` will be used
    - To avoid repeat values for `sample_name` all `sample_name` values will be suffixed with `sample`
    - Tests to check that the variety of different `sample_names` work with the 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Add `nf-test` to test new feature
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
- [x] Tested out in IRIDA-Next locally

[IRIDA-Next update]: https://github.com/phac-nml/irida-next/pull/678
[speciesabundance pipeline]: https://github.com/phac-nml/speciesabundance/pull/24
[staramrnf]: https://github.com/phac-nml/staramrnf/pull/28
[arboratornf]: https://github.com/phac-nml/arboratornf/pull/23
