### PR TITLE
Fix parameter name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An [example samplesheet](tests/data/samplesheets/samplesheet-sample_name.csv) ha
 
 # Parameters
 
-The main parameters are `--input` as defined above and `--output` for specifying the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run.
+The main parameters are `--input` as defined above and `--outdir` for specifying the output results directory. You may wish to provide `-profile singularity` to specify the use of singularity containers and `-r [branch]` to specify which GitHub branch you would like to run.
 
 ## Distance Method and Thresholds
 


### PR DESCRIPTION
As far as I can tell, in the README, `--output` is a typo, for `--outdir`. Passing in `--output` to this pipeline will not work, but using `--outdir` as specified later in the README will work as expected.

This PR simply fixes this typo. Please let me know if there are any additional requirements for this PR that I missed!

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] `README.md` is updated (including new tool citations and authors/contributors).
