### PR TITLE
Update Linting to nf-core v3.2.0

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,10 +14,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
         with:
           python-version: "3.12"
 
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
 
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
         with:
           python-version: "3.12"
           architecture: "x64"
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload linting log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:
           name: linting-logs
           path: |

--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download lint results
-        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
         with:
           workflow: linting.yml
           workflow_conclusion: completed

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ results/
 testing/
 testing*
 *.pyc
-*.swp
+null/

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,6 +1,6 @@
 repository_type: pipeline
 
-nf_core_version: "3.0.1"
+nf_core_version: "3.2.0"
 lint:
   files_exist:
     - assets/nf-core-gasnomenclature_logo_light.png

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,4 @@ testing/
 testing*
 *.pyc
 bin/
-tests/data/irida/sample_name_add_iridanext.output.json
+ro-crate-metadata.json


### PR DESCRIPTION
Updates the linter to nf-core v3.2.0:

```
nf-core pipelines lint
```

Leaves the following warnings:

```
nextflow_config: nf-validation has been detected in the pipeline. Please migrate to nf-schema:
https://nextflow-io.github.io/nf-schema/latest/migration_guide/
nextflow_config: Config manifest.version should end in dev: 0.3.2  
```
