### PR TITLE
update GAS 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Updated`
 
 - Update the `locidex` version to [0.3.0](https://pypi.org/project/locidex/0.3.0/). `locidex merge` has integrated the functionality of module `input_assure`. [PR 45](https://github.com/phac-nml/gasnomenclature/pull/45)
-- Update the `genomic address service` version to [0.1.5](https://github.com/phac-nml/genomic_address_service/pull/25%29). Changes how multiple samples without address are assigned addresses when belonging to the same cluster.
+- Update the `genomic address service` version to [0.1.5](https://github.com/phac-nml/genomic_address_service/pull/25%29). Changes how multiple samples without address are assigned addresses when belonging to the same cluster.git
 
 ### `Enhancement`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Updated`
 
 - Update the `locidex` version to [0.3.0](https://pypi.org/project/locidex/0.3.0/). `locidex merge` has integrated the functionality of module `input_assure`. [PR 45](https://github.com/phac-nml/gasnomenclature/pull/45)
+- Update the `genomic address service` version to [0.1.5](https://github.com/phac-nml/genomic_address_service/pull/25%29). Changes how multiple samples without address are assigned addresses when belonging to the same cluster.
 
 ### `Enhancement`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Updated`
 
 - Update the `locidex` version to [0.3.0](https://pypi.org/project/locidex/0.3.0/). `locidex merge` has integrated the functionality of module `input_assure`. [PR 45](https://github.com/phac-nml/gasnomenclature/pull/45)
-- Update the `genomic address service` version to [0.1.5](https://github.com/phac-nml/genomic_address_service/pull/25%29). Changes how multiple samples without address are assigned addresses when belonging to the same cluster.git
+- Update the `genomic address service` version to [0.1.5](https://github.com/phac-nml/genomic_address_service/pull/25%29). Changes how multiple samples without address are assigned addresses when belonging to the same cluster.
 
 ### `Enhancement`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Updated`
 
 - Update the `locidex` version to [0.3.0](https://pypi.org/project/locidex/0.3.0/). `locidex merge` has integrated the functionality of module `input_assure`. [PR 45](https://github.com/phac-nml/gasnomenclature/pull/45)
-- Update the `genomic address service` version to [0.1.5](https://github.com/phac-nml/genomic_address_service/pull/25%29). Changes how multiple samples without address are assigned addresses when belonging to the same cluster.
+- Update the `genomic address service` version to [0.1.5](https://github.com/phac-nml/genomic_address_service/releases/tag/0.1.5). Changes how multiple samples without address are assigned addresses when belonging to the same cluster. [PR 47](https://github.com/phac-nml/gasnomenclature/pull/47)
 
 ### `Enhancement`
 
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changes`
 
-- The output from `locidex merge` now includes a `MLST_error_report.csv` similar to that of `input_assure` (this file is also passed to `concat`)
+- The output from `locidex merge` now includes a `MLST_error_report.csv` similar to that of `input_assure` (this file is also passed to `concat`) [PR 45](https://github.com/phac-nml/gasnomenclature/pull/45)
 
 ## [0.4.0] - 2025/03/03
 

--- a/modules/local/gas/call/main.nf
+++ b/modules/local/gas/call/main.nf
@@ -5,8 +5,8 @@ process GAS_CALL{
     tag "Assigning Nomenclature"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.1.4--pyh7e72e81_0' :
-        'biocontainers/genomic_address_service:0.1.4--pyh7e72e81_0' }"
+        'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.1.5--pyhdfd78af_1' :
+        'biocontainers/genomic_address_service:0.1.5--pyhdfd78af_1' }"
 
     input:
     path(reference_clusters)

--- a/tests/data/called/expected_results_queries.txt
+++ b/tests/data/called/expected_results_queries.txt
@@ -3,4 +3,4 @@ sample1	1.1.1
 sample2	1.1.1
 sample3	1.1.2
 sampleQ	1.1.3
-sampleN	2.2.4
+sampleN	1.1.3

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -159,7 +159,7 @@ nextflow_pipeline {
             assert iridanext_metadata.containsKey("sampleN")
 
             assert iridanext_metadata.sampleQ."address" == "1.1.3"
-            assert iridanext_metadata.sampleN."address" == "2.2.4"
+            assert iridanext_metadata.sampleN."address" == "1.1.3"
         }
     }
 
@@ -225,7 +225,7 @@ nextflow_pipeline {
             // Check filter_query csv file
             lines = path("$launchDir/results/filter/new_addresses.tsv").readLines()
             assert lines.contains("sampleQ\tsampleQ\t1.1.3")
-            assert lines.contains("sampleR\tsampleR\t2.2.4")
+            assert lines.contains("sampleR\tsampleR\t1.1.3")
 
             // Check IRIDA Next JSON output
             assert path("$launchDir/results/iridanext.output.json").exists()
@@ -241,7 +241,7 @@ nextflow_pipeline {
             assert iridanext_metadata.containsKey("sampleR")
 
             assert iridanext_metadata.sampleQ."address" == "1.1.3"
-            assert iridanext_metadata.sampleR."address" == "2.2.4"
+            assert iridanext_metadata.sampleR."address" == "1.1.3"
         }
     }
 
@@ -389,7 +389,7 @@ nextflow_pipeline {
             // Check filter_query csv file
             lines = path("$launchDir/results/filter/new_addresses.tsv").readLines()
             assert lines.contains("sampleQ\tsample_1\t1.1.3")
-            assert lines.contains("sampleR\tsample4\t2.2.4")
+            assert lines.contains("sampleR\tsample4\t1.1.3")
 
             // Check IRIDA Next JSON output
             assert path("$launchDir/results/iridanext.output.json").exists()

--- a/tests/pipelines/main_append_databases.nf.test
+++ b/tests/pipelines/main_append_databases.nf.test
@@ -42,7 +42,6 @@ nextflow_pipeline {
 
             // Check IRIDA Next JSON output
             assert path("$launchDir/results/iridanext.output.json").exists()
-            assert path("$launchDir/results/iridanext.output.json").json == path("$baseDir/tests/data/irida/append_iridanext.output.json").json
 
             def iridanext_json = path("$launchDir/results/iridanext.output.json").json
             def iridanext_global = iridanext_json.files.global


### PR DESCRIPTION
- gasnomenclature should incroporate the latest GAS fixes (from [https://github.com/phac-nml/genomic_address_service/pull/25)](https://github.com/phac-nml/genomic_address_service/pull/25%29) - version 0.1.5
- update associated tests
