### PR TITLE
resolves #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## dev
+
+### `Fix`
+
+- Query samples now put into batches for `LOCIDEX_MERGE` fixing the issue [#52](https://github.com/phac-nml/gasnomenclature/issues/52). [PR #53](https://github.com/phac-nml/gasnomenclature/pull/53)
+
 ## [0.5.0] - 2025/04/02
 
 ### `Updated`

--- a/workflows/gas_nomenclature.nf
+++ b/workflows/gas_nomenclature.nf
@@ -147,7 +147,7 @@ workflow GAS_NOMENCLATURE {
     references = LOCIDEX_MERGE_REF(grouped_ref_files, ref_tag, merge_tsv)
     ch_versions = ch_versions.mix(references.versions)
 
-    queries = LOCIDEX_MERGE_QUERY(query_values, query_tag, merge_tsv)
+    queries = LOCIDEX_MERGE_QUERY(grouped_query_files, query_tag, merge_tsv)
     ch_versions = ch_versions.mix(queries.versions)
 
     // LOCIDEX Step 2:
@@ -159,7 +159,7 @@ workflow GAS_NOMENCLATURE {
         ref_tag,
         references.combined_profiles.collect().flatten().count())
 
-    // LOCIDEX Concatenate References
+    // LOCIDEX Concatenate Queries
     combined_queries = LOCIDEX_CONCAT_QUERY(queries.combined_profiles.collect(),
         queries.combined_error_report.collect(),
         query_tag,
@@ -177,7 +177,7 @@ workflow GAS_NOMENCLATURE {
         merged_references = combined_references.combined_profiles
     }
 
-    merged_queries = queries.combined_profiles
+    merged_queries = combined_queries.combined_profiles
 
     // PROFILE DISTS processes
 


### PR DESCRIPTION
Query samples were not being split into batches for locidex merge due to using wrong variables. Did not change outputs but meant the feature was not being implemented. These changes will fix the issue #52 
