### PR TITLE
Fix Issue #64 Fix Issue #63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.1] - 2025/05/dd
 
 ### `Fix`
+
 - Fix Issue [#64](https://github.com/phac-nml/gasnomenclature/issues/64) by providing a new process `copyFile` to rename duplicate MLST files. [PR #63](https://github.com/phac-nml/gasnomenclature/pull/63)
 - Fix Issue [#63](https://github.com/phac-nml/gasnomenclature/issues/63) changing input type for `merge_tsv`. [PR #63](https://github.com/phac-nml/gasnomenclature/pull/63)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - 2025/05/dd
+## [0.6.1] - 2025/05/26
 
 ### `Fix`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1] - 2025/05/dd
 
+### `Fix`
+- Fix Issue [#64](https://github.com/phac-nml/gasnomenclature/issues/64) by providing a new process `copyFile` to rename duplicate MLST files. [PR #63](https://github.com/phac-nml/gasnomenclature/pull/63)
+- Fix Issue [#63](https://github.com/phac-nml/gasnomenclature/issues/63) changing input type for `merge_tsv`. [PR #63](https://github.com/phac-nml/gasnomenclature/pull/63)
+
+### `Updated`
+
+- Update `profile_dists` to `v.1.0.6`. [PR #63](https://github.com/phac-nml/gasnomenclature/pull/63)
+
 ## [0.6.0] - 2025/05/12
 
 ### `Updated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2025/05/dd
+
 ## [0.6.0] - 2025/05/12
 
 ### `Updated`
@@ -133,3 +135,4 @@ Initial release of the Genomic Address Nomenclature pipeline to be used to assig
 [0.5.0]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.5.0
 [0.5.1]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.5.1
 [0.6.0]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.6.0
+[0.6.1]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.6.1

--- a/modules/local/copyFile/main.nf
+++ b/modules/local/copyFile/main.nf
@@ -1,0 +1,15 @@
+process COPY_FILE {
+    tag 'Copy and Rename file'
+    label "process_single"
+
+    input:
+    tuple val(meta), path(original_file), val(uniqueMLST)
+
+    output:
+    tuple val(meta), path("${meta.id}_${original_file}")
+
+    script:
+    """
+    cp $original_file ${meta.id}_${original_file}
+    """
+}

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -13,7 +13,7 @@ process LOCIDEX_MERGE {
     input:
     tuple val(batch_index), path(input_values) // [file(sample1), file(sample2), file(sample3), etc...]
     val  input_tag    // makes output unique and denotes the item as the reference or query to prevent name collision
-    val  merge_tsv
+    path  merge_tsv
 
     output:
     path("${input_tag}/profile_${batch_index}.tsv"),           emit: combined_profiles

--- a/modules/local/profile_dists/main.nf
+++ b/modules/local/profile_dists/main.nf
@@ -3,8 +3,8 @@ process PROFILE_DISTS{
     tag "Gathering Distances Between Reference and Query Profiles"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/profile_dists%3A1.0.5--pyhdfd78af_0' :
-        'biocontainers/profile_dists:1.0.5--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/profile_dists%3A1.0.6--pyhdfd78af_0' :
+        'biocontainers/profile_dists:1.0.6--pyhdfd78af_0' }"
 
     input:
     path query

--- a/nextflow.config
+++ b/nextflow.config
@@ -229,7 +229,7 @@ manifest {
     description     = """Gas Nomenclature assignment pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.6.0'
+    version         = '0.6.1'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/tests/data/called/expected_results_MLST_rename.text
+++ b/tests/data/called/expected_results_MLST_rename.text
@@ -1,0 +1,5 @@
+id	address
+sample1	1.1.1
+sample3	1.1.2
+sample2	1.1.1
+sampleQ	1.1.3

--- a/tests/data/called/expected_results_MLST_sample_rename.text
+++ b/tests/data/called/expected_results_MLST_sample_rename.text
@@ -1,0 +1,5 @@
+id	address
+sampleA	1.1.1
+sampleC	1.1.2
+sampleA_sample2	1.1.1
+sampleQ	1.1.3

--- a/tests/data/clusters/clusters_MLST_rename.tsv
+++ b/tests/data/clusters/clusters_MLST_rename.tsv
@@ -1,0 +1,4 @@
+id	address
+sample1	1.1.1
+sample3	1.1.2
+sample2	1.1.1

--- a/tests/data/clusters/clusters_MLST_sample_rename.tsv
+++ b/tests/data/clusters/clusters_MLST_sample_rename.tsv
@@ -1,0 +1,4 @@
+id	address
+sampleA	1.1.1
+sampleC	1.1.2
+sampleA_sample2	1.1.1

--- a/tests/data/samplesheets/samplesheet-duplicateMLST.csv
+++ b/tests/data/samplesheets/samplesheet-duplicateMLST.csv
@@ -1,0 +1,5 @@
+sample,mlst_alleles,genomic_address_name
+sampleQ,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sampleQ.mlst.json,
+sample1,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample1.mlst.json,1.1.1
+sample2,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample1.mlst.json,1.1.1
+sample3,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample3.mlst.json,1.1.2

--- a/tests/data/samplesheets/samplesheet_duplicate_name_and_MLST.csv
+++ b/tests/data/samplesheets/samplesheet_duplicate_name_and_MLST.csv
@@ -1,0 +1,5 @@
+sample,sample_name,mlst_alleles,genomic_address_name
+sampleQ,sampleQ,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sampleQ.mlst.json,
+sample1,sampleA,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample1.mlst.json,1.1.1
+sample2,sampleA,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample1.mlst.json,1.1.1
+sample3,sampleC,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample3.mlst.json,1.1.2

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -622,4 +622,89 @@ nextflow_pipeline {
             assert iridanext_metadata.F.genomic_address_name == "1.5.6"
         }
     }
+test("Testing for when there are repeat MLST allele files in multiple batches"){
+        // Previous versions of the pipeline would fail if there were repeat MLST allele files in the samplesheet.
+        tag "repeat-mlst"
+
+        when{
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-duplicateMLST.csv"
+                outdir = "results"
+                batch_size = 1
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check that the COPY_FILE process was called for the correct samples
+            assert path("$launchDir/results/copy/sample2_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleQ_sampleQ.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sample1_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sample3_sample3.mlst.json").exists()
+
+            // The merge_tsv file used in renaming the MLST profiles in locidex merge has the right file paths
+            def merge_tsv_content = path("$launchDir/results/write/results.csv")
+            assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sample2.*\/sample2_sample1\.mlst\.json$/} // The file path (minus the work directory)
+
+            // Check computed pairwise distances
+            def actual_distances = path("$launchDir/results/distances/results.text")
+            def expected_distances = path("$baseDir/tests/data/distances/expected_pairwise_dists.txt")
+            assert actual_distances.text == expected_distances.text
+
+            // Verify cluster file
+            def actual_cluster = path("$launchDir/results/cluster/clusters.tsv")
+            def expected_cluster = path("$baseDir/tests/data/clusters/clusters_MLST_rename.tsv")
+            assert actual_cluster.text == expected_cluster.text
+
+            // Check called clusters
+            def actual_calls = path("$launchDir/results/call/Called/results.text")
+            def expected_calls = path("$baseDir/tests/data/called/expected_results_MLST_rename.text")
+            assert actual_calls.text == expected_calls.text
+        }
+    }
+
+    test("Testing for when there are repeat MLST allele files in one single batch"){
+        // Previous versions of the pipeline would fail if there were repeat MLST allele files in the samplesheet.
+        tag "repeat-mlst-single-batch"
+
+        when{
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet-samplename.csv"
+                outdir = "results"
+                batch_size = 10
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check that the COPY_FILE process was called for the correct samples
+            assert path("$launchDir/results/copy/sample2_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleQ_sampleQ.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sample1_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sample3_sample3.mlst.json").exists()
+
+            // The merge_tsv file used in renaming the MLST profiles in locidex merge has the right file paths
+            def merge_tsv_content = path("$launchDir/results/write/results.csv")
+            assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sample2.*\/sample2_sample1\.mlst\.json$/} // The file path (minus the work directory)
+
+            // Check computed pairwise distances
+            def actual_distances = path("$launchDir/results/distances/results.text")
+            def expected_distances = path("$baseDir/tests/data/distances/expected_pairwise_dists.txt")
+            assert actual_distances.text == expected_distances.text
+
+            // Verify cluster file
+            def actual_cluster = path("$launchDir/results/cluster/clusters.tsv")
+            def expected_cluster = path("$baseDir/tests/data/clusters/clusters_MLST_rename.tsv")
+            assert actual_cluster.text == expected_cluster.text
+
+            // Check called clusters
+            def actual_calls = path("$launchDir/results/call/Called/results.text")
+            def expected_calls = path("$baseDir/tests/data/called/expected_results_MLST_rename.text")
+            assert actual_calls.text == expected_calls.text
+        }
+    }
 }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -671,7 +671,7 @@ test("Testing for when there are repeat MLST allele files in multiple batches"){
 
         when{
             params {
-                input = "$baseDir/tests/data/samplesheets/samplesheet-samplename.csv"
+                input = "$baseDir/tests/data/samplesheets/samplesheet-duplicateMLST.csv"
                 outdir = "results"
                 batch_size = 10
             }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -622,7 +622,7 @@ nextflow_pipeline {
             assert iridanext_metadata.F.genomic_address_name == "1.5.6"
         }
     }
-test("Testing for when there are repeat MLST allele files in multiple batches"){
+    test("Testing for when there are repeat MLST allele files in multiple batches"){
         // Previous versions of the pipeline would fail if there were repeat MLST allele files in the samplesheet.
         tag "repeat-mlst"
 
@@ -704,6 +704,42 @@ test("Testing for when there are repeat MLST allele files in multiple batches"){
             // Check called clusters
             def actual_calls = path("$launchDir/results/call/Called/results.text")
             def expected_calls = path("$baseDir/tests/data/called/expected_results_MLST_rename.text")
+            assert actual_calls.text == expected_calls.text
+        }
+    }
+
+    test("Testing for when there are repeat MLST allele files & repeat sample_name"){
+        tag "repeat-mlst-and-name"
+
+        when{
+            params {
+                input = "$baseDir/tests/data/samplesheets/samplesheet_duplicate_name_and_MLST.csv"
+                outdir = "results"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check that the COPY_FILE process was called for the correct samples
+            assert path("$launchDir/results/copy/sampleA_sample2_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sampleQ_sampleQ.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sample1_sample1.mlst.json").exists()
+            assert !path("$launchDir/results/copy/sample3_sample3.mlst.json").exists()
+
+            // The merge_tsv file used in renaming the MLST profiles in locidex merge has the right file paths
+            def merge_tsv_content = path("$launchDir/results/write/results.csv")
+            assert merge_tsv_content.text.split('\n').any { line -> line ==~ /^sampleA_sample2.*\/sampleA_sample2_sample1\.mlst\.json$/} // The file path (minus the work directory)
+
+            // Verify cluster file
+            def actual_cluster = path("$launchDir/results/cluster/clusters.tsv")
+            def expected_cluster = path("$baseDir/tests/data/clusters/clusters_MLST_sample_rename.tsv")
+            assert actual_cluster.text == expected_cluster.text
+
+            // Check called clusters
+            def actual_calls = path("$launchDir/results/call/Called/results.text")
+            def expected_calls = path("$baseDir/tests/data/called/expected_results_MLST_sample_rename.text")
             assert actual_calls.text == expected_calls.text
         }
     }

--- a/workflows/gas_nomenclature.nf
+++ b/workflows/gas_nomenclature.nf
@@ -24,6 +24,7 @@ include { loadIridaSampleIds                                   } from 'plugin/nf
 //
 
 include { WRITE_METADATA                         } from "../modules/local/write/main"
+include { COPY_FILE                              } from "../modules/local/copyFile/main"
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_REF     } from "../modules/local/locidex/merge/main"
 include { LOCIDEX_MERGE as LOCIDEX_MERGE_QUERY   } from "../modules/local/locidex/merge/main"
 include { LOCIDEX_CONCAT as LOCIDEX_CONCAT_QUERY } from "../modules/local/locidex/concat/main"
@@ -74,14 +75,16 @@ workflow GAS_NOMENCLATURE {
 
     ch_versions = Channel.empty()
 
-    // Track processed IDs
-    def processedIDs = [] as Set
+    // Track processed IDs and MLST files
+    def processedIDs  = [] as Set
+    def processedMLST  = [] as Set
 
     // Create a new channel of metadata from a sample sheet
     // NB: `input` corresponds to `params.input` and associated sample sheet schema
-    input = Channel.fromSamplesheet("input")
+    pre_input = Channel.fromSamplesheet("input")
     // and remove non-alphanumeric characters in sample_names (meta.id), whilst also correcting for duplicate sample_names (meta.id)
     .map { meta, mlst_file ->
+            uniqueMLST = true
             if (!meta.id) {
                 meta.id = meta.irida_id
             } else {
@@ -92,11 +95,26 @@ workflow GAS_NOMENCLATURE {
             while (processedIDs.contains(meta.id)) {
                 meta.id = "${meta.id}_${meta.irida_id}"
             }
+            // Check if the MLST file is unique
+            if (processedMLST.contains(mlst_file.baseName)) {
+                uniqueMLST = false
+            }
             // Add the ID to the set of processed IDs
             processedIDs << meta.id
-            tuple(meta, mlst_file)}.loadIridaSampleIds()
+            processedMLST << mlst_file.baseName
+            tuple(meta, mlst_file, uniqueMLST)}.loadIridaSampleIds()
 
-
+    // For the MLST files that are not unique, rename them
+    pre_input
+        .branch { meta, mlst_file, uniqueMLST ->
+            keep: uniqueMLST == true // Keep the unique MLST files as is
+            replace: uniqueMLST == false // Rename the non-unique MLST files to avoid collisions
+        }.set {mlst_file_rename}
+    renamed_input = COPY_FILE(mlst_file_rename.replace)
+    unchanged_input = mlst_file_rename.keep
+        .map { meta, mlst_file, uniqueMLST ->
+            tuple(meta, mlst_file) }
+    input = unchanged_input.mix(renamed_input)
 
     // Collect samples without genomic_address_name
     profiles = input.branch {


### PR DESCRIPTION
# Issue #64

Allow for multiple samples to include the same MLST files.

## Descripton

As seen in the issue when samplesheets had samples with the same MLST file provided 

```
sample,mlst_alleles,genomic_address_name
sampleQ,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sampleQ.mlst.json,
sample1,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample1.mlst.json,1.1.1
sample2,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample1.mlst.json,1.1.1
sample3,https://raw.githubusercontent.com/phac-nml/gasnomenclature/dev/tests/data/reports/sample3.mlst.json,1.1.2
```
Two types of errors would be generated. If the two same named MLST files were past to LOCIDEX_MERGE the error would occur there, or if in different batches then the error would occur downstream in PROFILE_DISTS

# Issue #63

Change the input type for `merge_tsv` to `path` not `val`

## PR checklist

- [x] `CHANGELOG.md` is updated.