### PR TITLE
adjust the logic for parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2025/08/06
+
+### `Modified`
+
+- Parameter logic for `PROFILE_DISTS` was changed to only use `--pd_max_cpus` if it is below the `task.cpus`. [PR #78](https://github.com/phac-nml/gasnomenclature/pull/78)
+- Remove `--max_mem` in favor of `--batch_size`. [PR #78](https://github.com/phac-nml/gasnomenclature/pull/78)
+
 ## [0.7.1] - 2025/08/05
 
 ### `Bug Fix`
@@ -185,3 +192,4 @@ Initial release of the Genomic Address Nomenclature pipeline to be used to assig
 [0.6.3]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.6.3
 [0.7.0]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.7.0
 [0.7.1]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.7.1
+[0.7.2]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.7.2

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -69,7 +69,6 @@ process {
 
         def pd_skip_arg = "--skip"
         def pd_count_missing_arg = "--count_missing"
-        def pd_max_cpus_args = { String max_cpus -> "--cpus ${max_cpus}" }
         def pd_max_batch_size_arg = { String max_batch_size -> "--batch_size ${max_batch_size}" }
 
 
@@ -88,9 +87,6 @@ process {
                 // Count missing as differences for profile_dists
                 params.pd_count_missing
                     ? pd_count_missing_arg : "",
-                // Set max cpus for profile_dists
-                params.pd_max_cpus
-                    ? pd_max_cpus_args(params.pd_max_cpus.toString()) : "",
                 // Manual selection of how many records should be included in a batch (defualt is null)
                 params.pd_max_batch_size != 0
                     ? pd_max_batch_size_arg(params.pd_max_batch_size.toString()) : ""

--- a/modules/local/profile_dists/main.nf
+++ b/modules/local/profile_dists/main.nf
@@ -31,6 +31,11 @@ process PROFILE_DISTS{
     if(columns){
         args = "--columns $columns " + args
     }
+    if(params.pd_max_cpus < task.cpus){
+        args = "--cpus $params.pd_max_cpus " + args
+    }else{
+        args = "--cpus ${task.cpus} " + args
+    }
 
     // --match_threshold $params.profile_dists.match_thresh \\
     prefix = "distances_pairwise"
@@ -41,8 +46,6 @@ process PROFILE_DISTS{
                 --file_type $params.pd_file_type \\
                 --missing_thresh $params.pd_missing_threshold \\
                 --sample_qual_thresh $params.pd_sample_quality_threshold \\
-                --max_mem ${task.memory.toGiga()} \\
-                --cpus ${task.cpus} \\
                 -o ${prefix}
 
     cat <<-END_VERSIONS > versions.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -234,7 +234,7 @@ manifest {
     description     = """Gas Nomenclature assignment pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '0.7.1'
+    version         = '0.7.2'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
Changing and fixing the logic of some of the parameters for PROFILE_DISTS:
1. Only use `pd_max_cpus` if it is less than task.cpus (which determined by `max_cpus` and what is defined by the label `process_high`
2. Remove `--max_mem`