### PR TITLE
Fix/preprocess remove loci

### DIFF
--- a/modules/local/preprocess_references/main.nf
+++ b/modules/local/preprocess_references/main.nf
@@ -3,8 +3,8 @@ process PREPROCESS_REFERENCES {
     label 'process_low'
     conda "bioconda::csvtk=0.22.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/csvtk:0.22.0--h9ee0642_1' :
-        'biocontainers/csvtk:0.22.0--h9ee0642_1' }"
+        'https://depot.galaxyproject.org/singularity/csvtk:0.31.0--h9ee0642_0' :
+        'biocontainers/csvtk:0.31.0--h9ee0642_0' }"
 
     input:
     path(reference_profiles)
@@ -34,7 +34,7 @@ process PREPROCESS_REFERENCES {
                 fi
             }
             columns=\$(cat_zcat $pd_columns | tr '\n' ',')
-            csvtk -t cut -f sample_id,"\${columns::-1}" $reference_profiles > loci_profiles.tsv
+            csvtk -t cut -m -f sample_id,"\${columns::-1}" $reference_profiles > loci_profiles.tsv
 
         """)
     } else {

--- a/modules/local/preprocess_references/main.nf
+++ b/modules/local/preprocess_references/main.nf
@@ -1,7 +1,7 @@
 process PREPROCESS_REFERENCES {
     tag "Preprocess reference profiles"
     label 'process_low'
-    conda "bioconda::csvtk=0.22.0"
+    conda "bioconda::csvtk=0.31.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/csvtk:0.31.0--h9ee0642_0' :
         'biocontainers/csvtk:0.31.0--h9ee0642_0' }"


### PR DESCRIPTION
The `--pd_columns` file can either have a header or have it skipped for `profile_dists`. `PREPROCESS_REFERENCES` uses this file to select columns via `cvstk cut` and if it occurs there it causes an error as the other files do not have this header. The following updates fix this issue

### `Updated`

- `PREPROCESS_REFERENCES` csvtk container updated to `0.31.0` for which `csvtk cut` has a `-m` `--allow-missing-col` missing column flag.