### PR TITLE
STRY0019104 - Test against GSP version of Nextflow in GitHub CI for all pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         NXF_VER:
           - "23.04.0"
+          - "24.10.3"
           - "latest-everything"
     steps:
       - name: Check out pipeline code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### `Updated`
+
+- Adding GitHub CI tests against Nextflow `24.10.3`. [PR #85](https://github.com/phac-nml/gasnomenclature/pull/85)
+
 ## [0.8.1] - 2025/09/05
 
 ### `Updated`


### PR DESCRIPTION
Adding GitHub CI tests against Nextflow `24.10.3`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
