### PR TITLE
Update genomic address service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Updated `genomic_address_service` to version `0.3.2`. [PR #92](https://github.com/phac-nml/gasnomenclature/pull/92).
+  - NOTE: Changes to `genomic_address_service` impact `gas mcluster` not used in this pipeline.
+
 ## [0.9.1] - 2025/12/01
 
 ### `Fixed`

--- a/modules/local/gas/call/main.nf
+++ b/modules/local/gas/call/main.nf
@@ -4,11 +4,9 @@ process GAS_CALL{
     label "process_high"
     tag "Assigning Nomenclature"
 
-    // Update singularlity to Galaxy depot if it becomes available.
-    // Likely: // https://depot.galaxyproject.org/singularity/genomic_address_service:0.2.0--pyhdfd78af_0
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.3.0--pyhdfd78af_0' :
-        'biocontainers/genomic_address_service:0.3.0--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.3.2--pyhdfd78af_0' :
+        'biocontainers/genomic_address_service:0.3.2--pyhdfd78af_0' }"
 
     input:
     path(reference_clusters)

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -10,7 +10,7 @@
                     "csvtk": "0.22.0"
                 },
                 "GAS_CALL": {
-                    "genomic_address_service": "0.3.0"
+                    "genomic_address_service": "0.3.2"
                 },
                 "LOCIDEX_MERGE_QUERY": {
                     "locidex": "0.4.0"
@@ -83,9 +83,9 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-11-27T14:44:03.628445191"
+        "timestamp": "2026-01-27T15:28:34.378610835"
     }
 }


### PR DESCRIPTION
Updated genomic address service to version 0.3.2, this update does not impact the command used by the pipeline `gas call` but `gas mcluster` but still good to have the most recent version of the software in the pipeline.
