### PR TITLE
0.9.2 Release

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -77,7 +77,7 @@ jobs:
             profile: "singularity"
         NXF_VER:
           - "24.10.3"
-          - "latest-everything"
+          - "25.10.4"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NFT_VER: "0.9.3"
+  NFT_VER: "0.9.2"
   NFT_WORKDIR: "~"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity
@@ -39,7 +39,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 4
+          max_shards: 7
 
       - name: debug
         run: |
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
-        profile: [docker, singularity]
+        profile: [conda, docker, singularity]
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
         # Exclude conda and singularity on dev
@@ -76,21 +76,22 @@ jobs:
           - isMain: false
             profile: "singularity"
         NXF_VER:
-          - "24.10.3"
           - "25.10.4"
+          - "24.10.3"
+          - "23.04.0"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test
-        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if we do, we don't want it to cause workflow failure
         env:
           NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
           NXF_VERSION: ${{ matrix.NXF_VER }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NFT_VER: "0.9.2"
+  NFT_VER: "0.9.3"
   NFT_WORKDIR: "~"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity
@@ -39,7 +39,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 7
+          max_shards: 4
 
       - name: debug
         run: |
@@ -76,21 +76,21 @@ jobs:
           - isMain: false
             profile: "singularity"
         NXF_VER:
-          - "25.10.4"
           - "24.10.3"
+          - "25.10.4"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
 
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test
-        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if we do, we don't want it to cause workflow failure
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if revert it back, we don't want it to cause workflow failure due issues 
         env:
           NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
           NXF_VERSION: ${{ matrix.NXF_VER }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test
-        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if revert it back, we don't want it to cause workflow failure due issues 
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }} # Currently not testing latest-everything, but if revert it back, we don't want it to cause workflow failure due issues
         env:
           NFT_WORKDIR: ${{ env.NFT_WORKDIR }}
           NXF_VERSION: ${{ matrix.NXF_VER }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
-        profile: [conda, docker, singularity]
+        profile: [docker, singularity]
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
         # Exclude conda and singularity on dev
@@ -78,7 +78,6 @@ jobs:
         NXF_VER:
           - "25.10.4"
           - "24.10.3"
-          - "23.04.0"
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.9.2] - 2026/04/9
 
 ### `Updated`
 
 - Updated `genomic_address_service` to version `0.3.2`. [PR #92](https://github.com/phac-nml/gasnomenclature/pull/92).
   - NOTE: Changes to `genomic_address_service` impact `gas mcluster` not used in this pipeline.
 - Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR #93](https://github.com/phac-nml/gasnomenclature/pull/93)
+
+### `Changed`
+
+- `LOCIDEX_MERGE` resource `label` needs to be switched to `process_single` so that the pipeline runs more efficiently. [PR #94](https://github.com/phac-nml/gasnomenclature/pull/94)
 
 ## [0.9.1] - 2025/12/01
 
@@ -247,3 +251,4 @@ Initial release of the Genomic Address Nomenclature pipeline to be used to assig
 [0.8.1]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.8.1
 [0.9.0]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.9.0
 [0.9.1]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.9.1
+[0.9.2]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### `Updated`
+
 - Updated `genomic_address_service` to version `0.3.2`. [PR #92](https://github.com/phac-nml/gasnomenclature/pull/92).
   - NOTE: Changes to `genomic_address_service` impact `gas mcluster` not used in this pipeline.
+- Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR #93](https://github.com/phac-nml/gasnomenclature/pull/93)
 
 ## [0.9.1] - 2025/12/01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Updated `genomic_address_service` to version `0.3.2`. [PR #92](https://github.com/phac-nml/gasnomenclature/pull/92).
+  - NOTE: Changes to `genomic_address_service` impact `gas mcluster` not used in this pipeline.
+
 ## [0.9.1] - 2025/12/01
 
 ### `Fixed`

--- a/modules/local/gas/call/main.nf
+++ b/modules/local/gas/call/main.nf
@@ -4,11 +4,9 @@ process GAS_CALL{
     label "process_high"
     tag "Assigning Nomenclature"
 
-    // Update singularlity to Galaxy depot if it becomes available.
-    // Likely: // https://depot.galaxyproject.org/singularity/genomic_address_service:0.2.0--pyhdfd78af_0
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.3.0--pyhdfd78af_0' :
-        'biocontainers/genomic_address_service:0.3.0--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/genomic_address_service%3A0.3.2--pyhdfd78af_0' :
+        'biocontainers/genomic_address_service:0.3.2--pyhdfd78af_0' }"
 
     input:
     path(reference_clusters)

--- a/modules/local/locidex/merge/main.nf
+++ b/modules/local/locidex/merge/main.nf
@@ -2,7 +2,7 @@
 
 process LOCIDEX_MERGE {
     tag 'Merge Profiles'
-    label 'process_medium'
+    label 'process_single'
     fair true
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@
     Default config options for all compute environments
 ----------------------------------------------------------------------------------------
 */
-
+//
 // Global default params, used in configs
 params {
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@
     Default config options for all compute environments
 ----------------------------------------------------------------------------------------
 */
-//
+
 // Global default params, used in configs
 params {
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -237,7 +237,7 @@ manifest {
     description     = """Gas Nomenclature assignment pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=24.10.3'
-    version         = '0.9.1'
+    version         = '0.9.2'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -15,7 +15,7 @@ config {
     profile "test"
 
     // list of filenames or patterns that should be trigger a full test run
-    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
+    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore', '.github/workflows/nf-test.yml'
 
     // load the necessary plugins
     plugins {

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -10,7 +10,7 @@
                     "csvtk": "0.22.0"
                 },
                 "GAS_CALL": {
-                    "genomic_address_service": "0.3.0"
+                    "genomic_address_service": "0.3.2"
                 },
                 "LOCIDEX_MERGE_QUERY": {
                     "locidex": "0.4.0"
@@ -83,9 +83,9 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-11-27T14:44:03.628445191"
+        "timestamp": "2026-01-27T15:28:34.378610835"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -22,7 +22,7 @@
                     "profile_dists": "1.0.10"
                 },
                 "Workflow": {
-                    "phac-nml/gasnomenclature": "0.9.1"
+                    "phac-nml/gasnomenclature": "0.9.2"
                 }
             },
             [
@@ -86,6 +86,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.6"
         },
-        "timestamp": "2026-01-27T15:28:34.378610835"
+        "timestamp": "2026-04-09T13:22:14.687414988"
     }
 }


### PR DESCRIPTION
## [0.9.2] - 2026/04/9

### `Updated`

- Updated `genomic_address_service` to version `0.3.2`. [PR #92](https://github.com/phac-nml/gasnomenclature/pull/92).
  - NOTE: Changes to `genomic_address_service` impact `gas mcluster` not used in this pipeline.
- Set nextflow version 25.10.4 to replace 'latest-everything' to confirm compatibility with next IRIDA-Next nextflow version in `.github/workflows` for nf-test. [PR #93](https://github.com/phac-nml/gasnomenclature/pull/93)

### `Changed`

- `LOCIDEX_MERGE` resource `label` needs to be switched to `process_single` so that the pipeline runs more efficiently. [PR #94](https://github.com/phac-nml/gasnomenclature/pull/94)


[0.9.2]: https://github.com/phac-nml/gasnomenclature/releases/tag/0.9.2